### PR TITLE
Avoid GFM extensions in Contributor Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,19 +106,17 @@ Before accepting a pull request, go through the following checklist:
 Release notes are pre-filled with titles and authors of merged pull requests.
 Labels group the pull requests into sections:
 
-| Label           | Section                                      |
-| ---             | ---                                          |
-| `breaking`      | :boom: Breaking Changes                      |
-| `bug`           | :beetle: Fixes                               |
-| `build`         | :package: Build System and Dependencies      |
-| `ci`            | :construction_worker: Continuous Integration |
-| `documentation` | :books: Documentation                        |
-| `enhancement`   | :rocket: Features                            |
-| `performance`   | :racehorse: Performance                      |
-| `refactoring`   | :hammer: Refactoring                         |
-| `removal`       | :fire: Removals and Deprecations             |
-| `style`         | :lipstick: Style                             |
-| `testing`       | :rotating_light: Testing                     |
+- :boom: Breaking Changes (`breaking`)
+- :beetle: Fixes (`bug`)
+- :package: Build System and Dependencies (`build`)
+- :construction_worker: Continuous Integration (`ci`)
+- :books: Documentation (`documentation`)
+- :rocket: Features (`enhancement`)
+- :racehorse: Performance (`performance`)
+- :hammer: Refactoring (`refactoring`)
+- :fire: Removals and Deprecations (`removal`)
+- :lipstick: Style (`style`)
+- :rotating_light: Testing (`testing`)
 
 ## How to make a release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,17 +106,17 @@ Before accepting a pull request, go through the following checklist:
 Release notes are pre-filled with titles and authors of merged pull requests.
 Labels group the pull requests into sections:
 
-- :boom: Breaking Changes (`breaking`)
-- :beetle: Fixes (`bug`)
-- :package: Build System and Dependencies (`build`)
-- :construction_worker: Continuous Integration (`ci`)
-- :books: Documentation (`documentation`)
-- :rocket: Features (`enhancement`)
-- :racehorse: Performance (`performance`)
-- :hammer: Refactoring (`refactoring`)
-- :fire: Removals and Deprecations (`removal`)
-- :lipstick: Style (`style`)
-- :rotating_light: Testing (`testing`)
+- 💥 Breaking Changes (`breaking`)
+- 🐞 Fixes (`bug`)
+- 📦 Build System and Dependencies (`build`)
+- 👷 Continuous Integration (`ci`)
+- 📚 Documentation (`documentation`)
+- 🚀 Features (`enhancement`)
+- 🐎 Performance (`performance`)
+- 🔨 Refactoring (`refactoring`)
+- 🔥 Removals and Deprecations (`removal`)
+- 💄 Style (`style`)
+- 🚨 Testing (`testing`)
 
 ## How to make a release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,9 +83,9 @@ Please open a
 [Pull Request](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pulls)
 to submit changes to this project.
 
-- [ ] Changes must be fully covered by unit tests.
-- [ ] Do not forget to update the documentation, where appropriate.
-- [ ] Follow [Black](https://black.readthedocs.io/) code style.
+- Changes must be fully covered by unit tests.
+- Do not forget to update the documentation, where appropriate.
+- Follow [Black](https://black.readthedocs.io/) code style.
 
 You can ensure that your changes adhere to the code style by reformatting with Black:
 
@@ -99,9 +99,9 @@ $ nox --session=black
 
 Before accepting a pull request, go through the following checklist:
 
-- [ ] The PR must pass all checks.
-- [ ] The PR must have a descriptive title.
-- [ ] The PR should be labelled with the kind of change (see below).
+- The PR must pass all checks.
+- The PR must have a descriptive title.
+- The PR should be labelled with the kind of change (see below).
 
 Release notes are pre-filled with titles and authors of merged pull requests.
 Labels group the pull requests into sections:
@@ -126,9 +126,9 @@ Labels group the pull requests into sections:
 
 Before making a release, go through the following checklist:
 
-- [ ] The master branch passes all checks.
-- [ ] The development release on [TestPyPI](https://test.pypi.org/project/cookiecutter-hypermodern-python-instance) looks good.
-- [ ] All PRs for the release have been merged.
+- The master branch passes all checks.
+- The development release on [TestPyPI](https://test.pypi.org/project/cookiecutter-hypermodern-python-instance) looks good.
+- All PRs for the release have been merged.
 
 Making a release is a two-step process:
 


### PR DESCRIPTION
GFM extensions, such as tables, emojis, and checkboxes, are not formatted correctly in Sphinx documentation. Markdown input for Sphinx is processed by `recommonmark`, an implementation of the CommonMark standard, which does not handle proprietary extensions such as GFM.