### PR TITLE
Remove coverage session

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,6 @@ jobs:
           architecture: x64
       - run: pip install nox==2019.11.9
       - run: pip install poetry==1.0.5
-      - run: nox --sessions tests-3.8 coverage
+      - run: nox --sessions tests-3.8 -- --cov --cov-report=xml
       - if: always()
         uses: codecov/codecov-action@v1

--- a/noxfile.py
+++ b/noxfile.py
@@ -188,13 +188,6 @@ def xdoctest(session: Session) -> None:
 
 
 @nox.session(python="3.8")
-def coverage(session: Session) -> None:
-    """Upload coverage data."""
-    install(session, "coverage[toml]")
-    session.run("coverage", "xml", "--fail-under=0")
-
-
-@nox.session(python="3.8")
 def docs(session: Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]


### PR DESCRIPTION
There is no longer any need for the coverage session, now that we upload to Codecov using their GitHub Action. Generate an XML coverage report from the tests session instead, passing `--cov-report=xml`.

