### PR TITLE
Configure dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "daily"
+    default_labels:
+      - "build"
+    allowed_updates:
+      - match:
+          update_type: "all"


### PR DESCRIPTION
This configuration differs from the defaults in two ways:

- The label `build` is used, like in our Release Drafter configuration.
- All updates are allowed, including subdependencies.