### PR TITLE
Configure mypy to be strict and pretty

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+check_untyped_defs = True
 disallow_any_generics = True
 disallow_incomplete_defs = True
 disallow_subclassing_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,7 @@
 [mypy]
 
-[mypy-nox.*,pytest]
+[mypy-nox.*]
+ignore_missing_imports = True
+
+[mypy-pytest]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 disallow_any_generics = True
+disallow_incomplete_defs = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,7 @@ disallow_any_generics = True
 disallow_incomplete_defs = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True
+disallow_untyped_decorators = True
 disallow_untyped_defs = True
 warn_unused_configs = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,7 @@ disallow_untyped_defs = True
 implicit_reexport = False
 no_implicit_optional = True
 show_column_numbers = True
+show_error_codes = True
 show_error_context = True
 strict_equality = True
 warn_redundant_casts = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ disallow_untyped_decorators = True
 disallow_untyped_defs = True
 implicit_reexport = False
 no_implicit_optional = True
+pretty = True
 show_column_numbers = True
 show_error_codes = True
 show_error_context = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,7 @@ disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
+implicit_reexport = False
 no_implicit_optional = True
 warn_redundant_casts = True
 warn_return_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ disallow_untyped_decorators = True
 disallow_untyped_defs = True
 implicit_reexport = False
 no_implicit_optional = True
+show_error_context = True
 strict_equality = True
 warn_redundant_casts = True
 warn_return_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ disallow_untyped_decorators = True
 disallow_untyped_defs = True
 no_implicit_optional = True
 warn_redundant_casts = True
+warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 disallow_any_generics = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True
+disallow_untyped_defs = True
 warn_unused_configs = True
 
 [mypy-nox.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,7 @@ disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
 no_implicit_optional = True
+warn_redundant_casts = True
 warn_unused_configs = True
 
 [mypy-nox.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 disallow_any_generics = True
+disallow_subclassing_any = True
 warn_unused_configs = True
 
 [mypy-nox.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,7 @@ disallow_untyped_defs = True
 no_implicit_optional = True
 warn_redundant_casts = True
 warn_return_any = True
+warn_unreachable = True
 warn_unused_configs = True
 warn_unused_ignores = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ disallow_untyped_decorators = True
 disallow_untyped_defs = True
 implicit_reexport = False
 no_implicit_optional = True
+strict_equality = True
 warn_redundant_casts = True
 warn_return_any = True
 warn_unreachable = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,6 +25,9 @@ disallow_untyped_decorators = False
 [mypy-tests.*]
 disallow_untyped_decorators = False
 
+[mypy-importlib_metadata]
+ignore_missing_imports = True
+
 [mypy-nox.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+disallow_any_generics = True
 warn_unused_configs = True
 
 [mypy-nox.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,6 +22,9 @@ warn_unused_ignores = True
 [mypy-noxfile]
 disallow_untyped_decorators = False
 
+[mypy-tests.*]
+disallow_untyped_decorators = False
+
 [mypy-nox.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,7 @@ disallow_untyped_defs = True
 no_implicit_optional = True
 warn_redundant_casts = True
 warn_unused_configs = True
+warn_unused_ignores = True
 
 [mypy-nox.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ disallow_untyped_decorators = True
 disallow_untyped_defs = True
 implicit_reexport = False
 no_implicit_optional = True
+show_column_numbers = True
 show_error_context = True
 strict_equality = True
 warn_redundant_casts = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+warn_unused_configs = True
 
 [mypy-nox.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,6 +19,9 @@ warn_unreachable = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
+[mypy-noxfile]
+disallow_untyped_decorators = False
+
 [mypy-nox.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,7 @@ disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
+no_implicit_optional = True
 warn_unused_configs = True
 
 [mypy-nox.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 disallow_any_generics = True
 disallow_subclassing_any = True
+disallow_untyped_calls = True
 warn_unused_configs = True
 
 [mypy-nox.*]

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ import contextlib
 from pathlib import Path
 import shutil
 import tempfile
-from typing import Iterator
+from typing import cast, Iterator
 
 import nox
 from nox.sessions import Session
@@ -56,7 +56,7 @@ class Poetry:
         output = self.session.run(
             "poetry", "version", external=True, silent=True, stderr=None
         )
-        return output.split()[1]
+        return cast(str, output).split()[1]
 
     def build(self, *args: str) -> None:
         """Build the package.

--- a/src/cookiecutter_hypermodern_python_instance/__init__.py
+++ b/src/cookiecutter_hypermodern_python_instance/__init__.py
@@ -1,8 +1,10 @@
 """Cookiecutter Hypermodern Python Instance."""
-try:
-    from importlib.metadata import version, PackageNotFoundError  # type: ignore
-except ImportError:  # pragma: no cover
-    from importlib_metadata import version, PackageNotFoundError  # type: ignore
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    from importlib.metadata import version, PackageNotFoundError  # pragma: no cover
+else:
+    from importlib_metadata import version, PackageNotFoundError  # pragma: no cover
 
 
 try:


### PR DESCRIPTION
Enable the strictness options associated with the `--strict` flag.

Also enable options for enhanced output (`--show-error-codes`, `--show-error-context`, `--show-column-numbers`, `--pretty`). 

Fix some issues in the code base due to the increased strictness:

- Use `sys.version_info` instead of `try...except ImportError`
- Ignore missing imports for `importlib_metadata`.
- Allow untyped decorators in Nox sessions and test suite.
- Fix `[no-any-return]` in `Poetry.version`.
