### PR TITLE
Add pre-commit hook for mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
         types: [python]
       - id: mypy
         name: mypy
-        entry: poetry run mypy
+        entry: env MYPYPATH=src poetry run mypy
         language: system
         types: [python]
+        require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         types: [python]
       - id: mypy
         name: mypy
-        entry: env MYPYPATH=src poetry run mypy
+        entry: poetry run mypy
         language: system
         types: [python]
         require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
         entry: poetry run flake8
         language: system
         types: [python]
+      - id: mypy
+        name: mypy
+        entry: poetry run mypy
+        language: system
+        types: [python]

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,7 @@ disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
 implicit_reexport = False
+mypy_path = src
 no_implicit_optional = True
 pretty = True
 show_column_numbers = True


### PR DESCRIPTION
This adds support for running mypy via pre-commit.

Like flake8 and black, mypy is run via Poetry using a [local hook]. This has the drawback that you need to run `poetry install` before you can use pre-commit with your project. On other hand, it allows you to manage these tools as development dependencies in Poetry. The alternative would be to have duplicate and potentially diverging version pins in the Poetry lock file and the pre-commit configuration. Also, pinning subdependencies does not appear to be very practical with pre-commit.

[local hook]: https://pre-commit.com/#repository-local-hooks

Set [mypy_path] in the configuration file pointing it to the `src` directory. This is required to avoid errors about missing imports related to your package when mypy is invoked on files located outside of the package, such as modules in the test suite. For example, pre-commit runs mypy on staged files only, so this would be a common issue with our mypy pre-commit hook.

This solution is preferred to passing `MYPYPATH` via the pre-commit hook, for two reasons:

- It is more portable because it does not require `env(1)` to be available.
- It will benefit uses of mypy outside of the pre-commit framework.

Here is an example of an error message resulting from running mypy on a test module without mypy_path:

```
tests/test_console.py:5:1: error: Skipping analyzing 'cookiecutter_hypermodern_python_instance': found module but no type hints or library stubs  [import]
    from cookiecutter_hypermodern_python_instance import console
    ^
tests/test_console.py:5:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
```

[mypy_path]: https://mypy.readthedocs.io/en/stable/config_file.html#config-file-import-discovery

The [require_serial] option is enabled like in pre-commit's own mypy mirror. The rationale for this appears to be performance, see https://github.com/pre-commit/mirrors-mypy/issues/2.

[require_serial]: https://pre-commit.com/#creating-new-hooks