### PR TITLE
Add py.typed marker file (PEP 561)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,7 +6,6 @@ disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
-mypy_path = src
 no_implicit_optional = True
 no_implicit_reexport = True
 pretty = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -148,6 +148,7 @@ def safety(session: Session) -> None:
 def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or locations
+    install_package(session)
     install(session, "mypy")
     session.run("mypy", *args)
 


### PR DESCRIPTION
Distribute inline type information using the `py.typed` marker file ([PEP 561]).

[pep 561]: https://www.python.org/dev/peps/pep-0561/

This allows us to remove `mypy_path` from mypy.ini.

Install the package into the Nox session for mypy. This is required to allow type-checking the test suite (when not also type-checking the package itself).