### PR TITLE
Omit redundant architecture key for setup-python action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,6 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: "3.8"
-          architecture: x64
       - run: pip install nox==2019.11.9
       - run: pip install poetry==1.0.5
       - run: nox --force-color --session=tests-3.8 -- --cov --cov-report=xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,6 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: "3.8"
-          architecture: x64
       - run: pip install nox==2019.11.9
       - run: pip install poetry==1.0.5
       - run: nox --force-color --session=docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: "3.8"
-          architecture: x64
       - run: pip install nox==2019.11.9
       - run: pip install poetry==1.0.5
       - run: nox --force-color

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -11,7 +11,6 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: "3.8"
-          architecture: x64
       - run: pip install poetry==1.0.5
       - run: >-
           poetry version patch &&

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
       - run: pip install nox==2019.11.9
       - run: pip install poetry==1.0.5
       - run: nox --force-color


### PR DESCRIPTION
There is no need to specify `architecture: x64` when using actions/setup-python.
x64 is the default architecture.