### PR TITLE
Fix tempfile usage in Poetry.export on Windows

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ class Poetry:
         self.session = session
 
     @contextlib.contextmanager
-    def export(self, *args: str) -> Iterator[str]:
+    def export(self, *args: str) -> Iterator[Path]:
         """Export the lock file to requirements format.
 
         Args:
@@ -36,16 +36,17 @@ class Poetry:
         Yields:
             The path to the requirements file.
         """
-        with tempfile.NamedTemporaryFile() as requirements:
+        with tempfile.TemporaryDirectory() as directory:
+            requirements = Path(directory) / "requirements.txt"
             self.session.run(
                 "poetry",
                 "export",
                 *args,
                 "--format=requirements.txt",
-                f"--output={requirements.name}",
+                f"--output={requirements}",
                 external=True,
             )
-            yield requirements.name
+            yield requirements
 
     def version(self) -> str:
         """Retrieve the package version.


### PR DESCRIPTION
Poetry.export uses tempfile.NamedTemporaryFile to create a temporary
requirements file, passing the name of the temporary file to `poetry export` via
its `--output` option.

Unfortunately, this does not work on Windows. On Windows NT and later, the name
attribute of the file-like object returned by tempfile.NamedTemporaryFile cannot
be used to open the file a second time, while the named temporary file is still
open.

https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile

Instead, use tempfile.TemporaryDirectory to create a temporary directory, and
store a file named `requirements.txt` in that directory. This technique should
be both secure and portable.