### PR TITLE
Ignore .mypy_cache/ in subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
+.mypy_cache/
 /.coverage
-/.mypy_cache/
 /.nox/
 /.python-version
 /.pytype/


### PR DESCRIPTION
Editor plugins may invoke mypy in subdirectories, leaving the cache directory all over the place.