### PR TITLE
Fix package installation in Nox sessions with non-final release versions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -61,13 +61,20 @@ class Poetry:
         )
         return cast(str, output).split()[1]
 
-    def build(self, *args: str) -> None:
+    def build(self, *args: str) -> str:
         """Build the package.
 
         Args:
             args: Command-line arguments for ``poetry build``.
+
+        Returns:
+            The basename of the wheel built by Poetry.
         """
-        self.session.run("poetry", "build", *args, external=True)
+        output = self.session.run(
+            "poetry", "build", *args, external=True, silent=True, stderr=None
+        )
+        assert isinstance(output, str)  # noqa: S101
+        return output.split()[-1]
 
 
 def install_package(session: Session) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -94,12 +94,8 @@ def install_package(session: Session) -> None:
     with poetry.export() as requirements:
         session.install(f"--requirement={requirements}")
 
-    poetry.build("--format=wheel")
-
-    version = poetry.version()
-    session.install(
-        "--no-deps", "--force-reinstall", f"dist/{package}-{version}-py3-none-any.whl"
-    )
+    wheel = poetry.build("--format=wheel")
+    session.install("--no-deps", "--force-reinstall", f"dist/{wheel}")
 
 
 def install(session: Session, *args: str) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,6 @@ import sys
 import tempfile
 from pathlib import Path
 from textwrap import dedent
-from typing import cast
 from typing import Iterator
 
 import nox
@@ -49,17 +48,6 @@ class Poetry:
                 external=True,
             )
             yield requirements
-
-    def version(self) -> str:
-        """Retrieve the package version.
-
-        Returns:
-            The package version.
-        """
-        output = self.session.run(
-            "poetry", "version", external=True, silent=True, stderr=None
-        )
-        return cast(str, output).split()[1]
 
     def build(self, *args: str) -> str:
         """Build the package.


### PR DESCRIPTION
Closes #470

- Return the basename of the wheel from Poetry.build
- Locate wheel using Poetry's output when installing
- Remove unused function Poetry.version
