### PR TITLE
Do not ignore missing type imports from pytest

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -18,9 +18,3 @@ warn_return_any = True
 warn_unreachable = True
 warn_unused_configs = True
 warn_unused_ignores = True
-
-[mypy-pytest]
-ignore_missing_imports = True
-
-[mypy-tests.*]
-disallow_untyped_decorators = False

--- a/noxfile.py
+++ b/noxfile.py
@@ -107,7 +107,7 @@ def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests", "docs/conf.py"]
     session.install(".")
-    session.install("mypy")
+    session.install("mypy", "pytest")
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")


### PR DESCRIPTION
The pytest 6.0.0 release added support for static typing, with types
distributed inline with the package (as per PEP 561).

This PR removes the following pytest-related exceptions from mypy.ini:

- Remove `ignore_missing_imports` for `pytest`
- Remove `allow_untyped_decorators` for `tests`

For this to work, we also need to install pytest into the Nox session for mypy.
This allows mypy to access the type information distributed with pytest.

Closes #552
