### PR TITLE
Include test suite in code coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ source = ["src", "*/site-packages"]
 
 [tool.coverage.run]
 branch = true
-source = ["cookiecutter_hypermodern_python_instance"]
+source = ["cookiecutter_hypermodern_python_instance", "tests"]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ cookiecutter-hypermodern-python-instance = "cookiecutter_hypermodern_python_inst
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]
+tests = ["tests", "*/tests"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Include the test suite in code coverage, via the [coverage.run.source] setting.

Rationale:

- Tests are code.
- Identify tests that aren’t running.
- Ensure that test helpers are used and tested.

Caveats:

- Coverage may require extra configuration if tests are deliberately excluded.
- Tests may clutter the coverage report. Use `--skip-covered` if this is an issue.
- The coverage metric generally goes up.

See https://nedbatchelder.com/blog/202008/you_should_include_your_tests_in_coverage.html

This PR also updates the [coverage.paths] setting, to map paths for the test suite to the local source tree. By default, coverage data contains absolute paths for the test suite. During CI, coverage data from various runners is combined in an environment where these paths do not exist. This results in errors like the following:

```
No source for code: '/Users/runner/work/cookiecutter-hypermodern-python-instance/cookiecutter-hypermodern-python-instance/tests/__init__.py'.
Aborting report output, consider using -i.
```

The [coverage.run.relative_files] setting is not an option here due to https://github.com/nedbat/coveragepy/issues/991: Windows paths are stored with backslashes, triggering `No source` errors when the coverage data is combined on other platforms, such as the Ubuntu runner used in our coverage job:

```
No source for code: '/path/to/cookiecutter-hypermodern-python-instance/tests\__init__.py'.
```

Note the backslash in the filename reported in the error message. If that upstream issue was fixed, we'd still need `coverage.paths` for `src` though. This is because relative paths for the installed package still include the location of the various Nox environments.

[coverage.run.source]: https://coverage.readthedocs.io/en/coverage-5.3/source.html#source
[coverage.paths]: https://coverage.readthedocs.io/en/coverage-5.3/config.html#paths
[coverage.run.relative_files]: https://coverage.readthedocs.io/en/coverage-5.3/config.html#config-run-relative-files
