### PR TITLE
Configure darglint to allow long docstrings without signatures

### DIFF
--- a/.darglint
+++ b/.darglint
@@ -1,2 +1,2 @@
 [darglint]
-strictness = short
+strictness = long


### PR DESCRIPTION
The current setting of `short` is too strict and discourages from writing long
docstrings when it does not make sense to include the full function signature
boilerplate, for example in internal APIs with self-explanatory signatures.
