### PR TITLE
Remove types-click from Nox session for mypy

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -119,7 +119,7 @@ def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests", "docs/conf.py"]
     session.install(".")
-    session.install("mypy", "pytest", "types-click")
+    session.install("mypy", "pytest")
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")

--- a/src/cookiecutter_hypermodern_python_instance/__main__.py
+++ b/src/cookiecutter_hypermodern_python_instance/__main__.py
@@ -2,12 +2,8 @@
 import click
 
 
-# @click.version_option results in "untyped decorator" error
-# https://github.com/python/typeshed/issues/5642
-
-
 @click.command()
-@click.version_option()  # type: ignore[misc]
+@click.version_option()
 def main() -> None:
     """Cookiecutter Hypermodern Python Instance."""
 


### PR DESCRIPTION
- Remove types-click from Nox session for mypy
- Remove unused `type: ignore` on `@click.version_option`
