### PR TITLE
Use Poetry development dependencies and drop nox-poetry

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
 pip==21.3.1
 nox==2021.10.1
 nox-poetry==0.8.6
-poetry==1.1.11
+poetry==1.2.0a2
 virtualenv==20.10.0

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -47,7 +47,6 @@ You need Python 3.7+ and the following tools:
 
 - Poetry_
 - Nox_
-- nox-poetry_
 
 Install the package with development requirements:
 
@@ -65,7 +64,6 @@ or the command-line interface:
 
 .. _Poetry: https://python-poetry.org/
 .. _Nox: https://nox.thea.codes/
-.. _nox-poetry: https://nox-poetry.readthedocs.io/
 
 
 How to test the project

--- a/noxfile.py
+++ b/noxfile.py
@@ -153,11 +153,19 @@ def coverage(session: nox.Session) -> None:
     session.run("coverage", *args)
 
 
-@session(python=python_versions)
-def typeguard(session: Session) -> None:
+@nox.session(python=python_versions)
+def typeguard(session: nox.Session) -> None:
     """Runtime type checking using Typeguard."""
-    session.install(".")
-    session.install("pytest", "typeguard", "pygments")
+    session.run(
+        "poetry",
+        "install",
+        "--with",
+        "typeguard",
+        "--with",
+        "tests",
+        "--sync",
+        external=True,
+    )
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,19 +39,12 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
 
     This function installs the package located in the current directory into the
     session's virtual environment.
-
-    A :ref:`constraints file <Constraints Files>` is generated for the
-    package dependencies using :meth:`export_requirements`, and passed to
-    :ref:`pip install` via its ``--constraint`` option. This ensures that
-    core dependencies are installed using the versions specified in Poetry's
-    lock file.
     """
     from nox_poetry.core import Session_install
     from nox_poetry.poetry import CommandSkippedError
 
     try:
         package = self.build_package()
-        requirements = self.export_requirements()
     except CommandSkippedError:
         return
 
@@ -59,7 +52,7 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
         "pip", "uninstall", "--yes", package, silent=True
     )
 
-    Session_install(self.session, f"--constraint={requirements}", package)  # type: ignore[attr-defined]
+    Session_install(self.session, package)  # type: ignore[attr-defined]
 
 
 def install(session: nox.Session, *, groups: Iterable[str], only: bool = False) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -49,9 +49,7 @@ def build_package(self: nox_poetry.sessions._PoetrySession) -> str:
     Returns:
         The file URL for the distribution package.
     """
-    wheel = Path("dist") / self.poetry.build(  # type: ignore[attr-defined]
-        format=nox_poetry.poetry.DistributionFormat.WHEEL
-    )
+    wheel = Path("dist") / self.poetry.build(format="wheel")  # type: ignore[attr-defined]
     url: str = wheel.resolve().as_uri()
 
     return url

--- a/noxfile.py
+++ b/noxfile.py
@@ -104,7 +104,6 @@ def export_requirements(session: nox.Session) -> Path:
     Raises:
         CommandSkippedError: The command `poetry export` was not executed.
     """
-    path = session.cache_dir / "requirements.txt"
     output = session.run_always(
         "poetry",
         "export",
@@ -132,6 +131,8 @@ def export_requirements(session: nox.Session) -> Path:
             yield line
 
     text = "".join(_stripwarnings(output.splitlines(keepends=True)))
+
+    path = session.cache_dir / "requirements.txt"
     path.write_text(text)
 
     return path

--- a/noxfile.py
+++ b/noxfile.py
@@ -49,10 +49,8 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     from nox_poetry.core import Session_install
     from nox_poetry.poetry import CommandSkippedError
 
-    distribution_format = nox_poetry.poetry.DistributionFormat.WHEEL
-
     try:
-        package = self.build_package(distribution_format=distribution_format)
+        package = self.build_package()
         requirements = self.export_requirements()
     except CommandSkippedError:
         return

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,9 +46,9 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     try:
         package = self.build_package()
     except CommandSkippedError:
-        return
-
-    Session_install(self.session, package)  # type: ignore[attr-defined]
+        pass
+    else:
+        Session_install(self.session, package)  # type: ignore[attr-defined]
 
 
 def install(session: nox.Session, *, groups: Iterable[str], only: bool = False) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,7 @@ nox.options.sessions = (
 )
 
 
-def build_package(self: nox_poetry.sessions._PoetrySession) -> str:
+def build_package(session: nox.Session) -> str:
     """Build a distribution archive for the package.
 
     This function uses `poetry build`_ to build a wheel for the local package,
@@ -61,13 +61,8 @@ def build_package(self: nox_poetry.sessions._PoetrySession) -> str:
     Raises:
         CommandSkippedError: The command `poetry build` was not executed.
     """
-    output = self.poetry.session.run_always(  # type: ignore[attr-defined]
-        "poetry",
-        "build",
-        "--format=wheel",
-        external=True,
-        silent=True,
-        stderr=None,
+    output = session.run_always(
+        "poetry", "build", "--format=wheel", external=True, silent=True, stderr=None
     )
 
     if output is None:
@@ -91,7 +86,7 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     session's virtual environment.
     """
     try:
-        package = build_package(self)
+        package = build_package(self.poetry.session)  # type: ignore[attr-defined]
     except nox_poetry.poetry.CommandSkippedError:
         pass
     else:

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,4 @@
 """Nox sessions."""
-import hashlib
 import shutil
 import sys
 from pathlib import Path
@@ -136,10 +135,6 @@ def export_requirements(self: nox_poetry.sessions._PoetrySession) -> Path:
     versions specified in ``poetry.lock``. The requirements file includes
     both core and development dependencies.
 
-    The requirements file is stored in a per-session temporary directory,
-    together with a hash digest over ``poetry.lock`` to avoid generating the
-    file when the dependencies have not changed since the last run.
-
     .. _poetry export: https://python-poetry.org/docs/cli/#export
 
     Returns:
@@ -152,14 +147,7 @@ def export_requirements(self: nox_poetry.sessions._PoetrySession) -> Path:
     tmpdir.mkdir(exist_ok=True, parents=True)
 
     path = tmpdir / "requirements.txt"
-    hashfile = tmpdir / f"{path.name}.hash"
-
-    lockdata = Path("poetry.lock").read_bytes()
-    digest = hashlib.blake2b(lockdata).hexdigest()
-
-    if not hashfile.is_file() or hashfile.read_text() != digest:
-        path.write_text(self.poetry.export())  # type: ignore[attr-defined]
-        hashfile.write_text(digest)
+    path.write_text(self.poetry.export())  # type: ignore[attr-defined]
 
     return path
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Iterable
 from typing import Iterator
+from typing import List
 
 import nox
 
@@ -88,6 +89,15 @@ def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -
     session.install(wheel.resolve().as_uri())
 
 
+def extras(self: nox_poetry.poetry.Config) -> List[str]:
+    """Return the package extras."""
+    extras = self._config.get("extras", {})
+    assert isinstance(extras, dict) and all(  # noqa: S101
+        isinstance(extra, str) for extra in extras
+    )
+    return list(extras)
+
+
 def export(self: nox_poetry.poetry.Poetry) -> str:
     """Export the lock file to requirements format.
 
@@ -103,7 +113,7 @@ def export(self: nox_poetry.poetry.Poetry) -> str:
         "export",
         "--format=requirements.txt",
         "--dev",
-        *[f"--extras={extra}" for extra in config.extras],
+        *[f"--extras={extra}" for extra in extras(config)],
         "--without-hashes",
         external=True,
         silent=True,

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,6 +56,8 @@ def installroot(session: nox.Session) -> None:
 
     .. _poetry build: https://python-poetry.org/docs/cli/#export
 
+    Args:
+        session: The Session object.
     """
     output = session.run_always(
         "poetry", "build", "--format=wheel", external=True, silent=True, stderr=None

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,13 +33,13 @@ nox.options.sessions = (
 )
 
 
-def installroot(session: nox.Session) -> None:
-    """Install the root package into a Nox session using Poetry.
+def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -> None:
+    """Install the dependency groups using Poetry.
 
-    This function installs the package located in the current directory into the
-    session's virtual environment. The function uses `poetry build`_ to build a
-    wheel for the local package. It returns a file URL with the absolute path to
-    the built archive.
+    With ``root=True``, the function installs the package located in the current
+    directory into the session's virtual environment. The function uses `poetry
+    build`_ to build a wheel for the local package. It returns a file URL with
+    the absolute path to the built archive.
 
     The filename of the archive is extracted from the output Poetry writes
     to standard output, which currently looks like this::
@@ -57,26 +57,6 @@ def installroot(session: nox.Session) -> None:
 
     Args:
         session: The Session object.
-    """
-    output = session.run_always(
-        "poetry", "build", "--format=wheel", external=True, silent=True, stderr=None
-    )
-
-    if output is None:
-        # The package build was skipped due to `--no-install`.
-        return
-
-    assert isinstance(output, str)  # noqa: S101
-
-    wheel = Path("dist") / output.split()[-1]
-    session.install(wheel.resolve().as_uri())
-
-
-def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -> None:
-    """Install the dependency groups using Poetry.
-
-    Args:
-        session: The Session object.
         groups: The dependency groups to install.
         root: Install the root package.
     """
@@ -91,7 +71,18 @@ def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -
     if not root:
         return
 
-    installroot(session)
+    output = session.run_always(
+        "poetry", "build", "--format=wheel", external=True, silent=True, stderr=None
+    )
+
+    if output is None:
+        # The package build was skipped due to `--no-install`.
+        return
+
+    assert isinstance(output, str)  # noqa: S101
+
+    wheel = Path("dist") / output.split()[-1]
+    session.install(wheel.resolve().as_uri())
 
 
 def activate_virtualenv_in_precommit_hooks(session: nox.Session) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,7 +50,6 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     from nox_poetry.poetry import CommandSkippedError
 
     distribution_format = nox_poetry.poetry.DistributionFormat.WHEEL
-    extras = ()
 
     try:
         package = self.build_package(distribution_format=distribution_format)
@@ -61,12 +60,6 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     self.session.run_always(  # type: ignore[attr-defined]
         "pip", "uninstall", "--yes", package, silent=True
     )
-
-    suffix = ",".join(extras)
-    if suffix.strip():
-        suffix = suffix.join("[]")
-        name = self.poetry.config.name  # type: ignore[attr-defined]
-        package = f"{name}{suffix} @ {package}"
 
     Session_install(self.session, f"--constraint={requirements}", package)  # type: ignore[attr-defined]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,12 +34,7 @@ nox.options.sessions = (
 )
 
 
-def installroot(
-    self: nox_poetry.sessions._PoetrySession,
-    *,
-    distribution_format: str = nox_poetry.poetry.DistributionFormat.WHEEL,
-    extras: Iterable[str] = (),
-) -> None:
+def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     """Install the root package into a Nox session using Poetry.
 
     This function installs the package located in the current directory into the
@@ -50,13 +45,12 @@ def installroot(
     :ref:`pip install` via its ``--constraint`` option. This ensures that
     core dependencies are installed using the versions specified in Poetry's
     lock file.
-
-    Args:
-        distribution_format: The distribution format, either wheel or sdist.
-        extras: Extras to install for the package.
     """
     from nox_poetry.core import Session_install
     from nox_poetry.poetry import CommandSkippedError
+
+    distribution_format = nox_poetry.poetry.DistributionFormat.WHEEL
+    extras = ()
 
     try:
         package = self.build_package(distribution_format=distribution_format)

--- a/noxfile.py
+++ b/noxfile.py
@@ -48,10 +48,6 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     except CommandSkippedError:
         return
 
-    self.session.run_always(  # type: ignore[attr-defined]
-        "pip", "uninstall", "--yes", package, silent=True
-    )
-
     Session_install(self.session, package)  # type: ignore[attr-defined]
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,8 +8,7 @@ from typing import Iterable
 import nox
 
 try:
-    import nox_poetry.sessions
-    import nox_poetry.poetry
+    import nox_poetry
 except ImportError:
     message = f"""\
     Nox failed to import the 'nox-poetry' package.

--- a/noxfile.py
+++ b/noxfile.py
@@ -107,7 +107,7 @@ def export_requirements(self: nox_poetry.sessions._PoetrySession) -> Path:
     # Avoid ``session.virtualenv.location`` because PassthroughEnv does not
     # have it. We'll just create a fake virtualenv directory in this case.
 
-    tmpdir = Path(self.session._runner.envdir) / "tmp"
+    tmpdir = Path(self.session._runner.envdir) / "tmp"  # type: ignore[attr-defined]
     tmpdir.mkdir(exist_ok=True, parents=True)
 
     path = tmpdir / "requirements.txt"
@@ -117,7 +117,7 @@ def export_requirements(self: nox_poetry.sessions._PoetrySession) -> Path:
     digest = hashlib.blake2b(lockdata).hexdigest()
 
     if not hashfile.is_file() or hashfile.read_text() != digest:
-        path.write_text(self.poetry.export())
+        path.write_text(self.poetry.export())  # type: ignore[attr-defined]
         hashfile.write_text(digest)
 
     return path

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,6 +34,52 @@ nox.options.sessions = (
 )
 
 
+def build(self: nox_poetry.poetry.Poetry, *, format: str) -> str:
+    """Build the package.
+
+    The filename of the archive is extracted from the output Poetry writes
+    to standard output, which currently looks like this::
+
+        Building foobar (0.1.0)
+        - Building wheel
+        - Built foobar-0.1.0-py3-none-any.whl
+
+    This is brittle, but it has the advantage that it does not rely on
+    assumptions such as having a clean ``dist`` directory, or
+    reconstructing the filename from the package metadata. (Poetry does not
+    use PEP 440 for version numbers, so this is non-trivial.)
+
+    Args:
+        format: The distribution format, either wheel or sdist.
+
+    Returns:
+        The basename of the wheel built by Poetry.
+
+    Raises:
+        CommandSkippedError: The command `poetry build` was not executed.
+    """
+    if not isinstance(format, nox_poetry.poetry.DistributionFormat):
+        format = nox_poetry.poetry.DistributionFormat(format)
+
+    output = self.session.run_always(
+        "poetry",
+        "build",
+        f"--format={format}",
+        external=True,
+        silent=True,
+        stderr=None,
+    )
+
+    if output is None:
+        raise nox_poetry.poetry.CommandSkippedError(
+            "The command `poetry build` was not executed"
+            " (a possible cause is specifying `--no-install`)"
+        )
+
+    assert isinstance(output, str)  # noqa: S101
+    return output.split()[-1]
+
+
 def build_package(self: nox_poetry.sessions._PoetrySession) -> str:
     """Build a distribution archive for the package.
 
@@ -49,7 +95,7 @@ def build_package(self: nox_poetry.sessions._PoetrySession) -> str:
     Returns:
         The file URL for the distribution package.
     """
-    wheel = Path("dist") / self.poetry.build(format="wheel")  # type: ignore[attr-defined]
+    wheel = Path("dist") / build(self.poetry, format="wheel")  # type: ignore[attr-defined]
     url: str = wheel.resolve().as_uri()
 
     return url

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,16 +34,12 @@ nox.options.sessions = (
 )
 
 
-def build_package(
-    self: nox_poetry.sessions._PoetrySession,
-    *,
-    distribution_format: str = nox_poetry.poetry.DistributionFormat.WHEEL,
-) -> str:
+def build_package(self: nox_poetry.sessions._PoetrySession) -> str:
     """Build a distribution archive for the package.
 
-    This function uses `poetry build`_ to build a wheel or sdist archive for
-    the local package, as specified via the ``distribution_format`` parameter.
-    It returns a file URL with the absolute path to the built archive.
+    This function uses `poetry build`_ to build a wheel for the local package,
+    as specified via the ``distribution_format`` parameter. It returns a file
+    URL with the absolute path to the built archive.
 
     .. _poetry build: https://python-poetry.org/docs/cli/#export
 
@@ -54,15 +50,9 @@ def build_package(
         The file URL for the distribution package.
     """
     wheel = Path("dist") / self.poetry.build(  # type: ignore[attr-defined]
-        format=distribution_format
+        format=nox_poetry.poetry.DistributionFormat.WHEEL
     )
     url: str = wheel.resolve().as_uri()
-
-    if (
-        nox_poetry.poetry.DistributionFormat(distribution_format)
-        is nox_poetry.poetry.DistributionFormat.SDIST
-    ):
-        url += f"#egg={self.poetry.config.name}"  # type: ignore[attr-defined]
 
     return url
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,18 +8,6 @@ from typing import Iterator
 
 import nox
 
-try:
-    import nox_poetry.poetry
-    import nox_poetry.sessions
-except ImportError:
-    message = f"""\
-    Nox failed to import the 'nox-poetry' package.
-
-    Please install it using the following command:
-
-    {sys.executable} -m pip install nox-poetry"""
-    raise SystemExit(dedent(message)) from None
-
 
 package = "cookiecutter_hypermodern_python_instance"
 python_versions = ["3.10", "3.9", "3.8", "3.7"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ from typing import Iterable
 import nox
 
 try:
-    from nox_poetry import Session
+    import nox_poetry
 except ImportError:
     message = f"""\
     Nox failed to import the 'nox-poetry' package.
@@ -50,7 +50,7 @@ def install(session: nox.Session, *, groups: Iterable[str], only: bool = False) 
         external=True,
     )
     if not only:
-        Session(session).poetry.installroot()
+        nox_poetry.Session(session).poetry.installroot()
 
 
 def activate_virtualenv_in_precommit_hooks(session: nox.Session) -> None:
@@ -116,7 +116,7 @@ def precommit(session: nox.Session) -> None:
 @nox.session(python="3.10")
 def safety(session: nox.Session) -> None:
     """Scan dependencies for insecure packages."""
-    requirements = Session(session).poetry.export_requirements()
+    requirements = nox_poetry.Session(session).poetry.export_requirements()
     install(session, groups=["safety"], only=True)
     session.run("safety", "check", "--full-report", f"--file={requirements}")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,11 +67,7 @@ def installroot(session: nox.Session) -> None:
     assert isinstance(output, str)  # noqa: S101
 
     wheel = Path("dist") / output.split()[-1]
-    url: str = wheel.resolve().as_uri()
-
-    package = url
-
-    session.install(package)
+    session.install(wheel.resolve().as_uri())
 
 
 def install(session: nox.Session, *, groups: Iterable[str], only: bool = False) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,6 @@ from typing import Iterable
 import nox
 
 try:
-    import nox_poetry.poetry
     import nox_poetry.sessions
 except ImportError:
     message = f"""\
@@ -118,8 +117,7 @@ def export_requirements(self: nox_poetry.sessions._PoetrySession) -> Path:
     digest = hashlib.blake2b(lockdata).hexdigest()
 
     if not hashfile.is_file() or hashfile.read_text() != digest:
-        constraints = nox_poetry.sessions.to_constraints(self.poetry.export())
-        path.write_text(constraints)
+        path.write_text(self.poetry.export())
         hashfile.write_text(digest)
 
     return path

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,7 +76,7 @@ def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -
     session.install(wheel.resolve().as_uri())
 
 
-def export_requirements(session: nox.Session) -> Path:
+def export_requirements(session: nox.Session, *, extras: Iterable[str] = ()) -> Path:
     """Export a requirements file from Poetry.
 
     This function uses ``poetry export`` to generate a requirements file
@@ -86,6 +86,7 @@ def export_requirements(session: nox.Session) -> Path:
 
     Args:
         session: The Session object.
+        extras: Extras supported by the project.
 
     Returns:
         The path to the requirements file.
@@ -96,6 +97,7 @@ def export_requirements(session: nox.Session) -> Path:
         "--format=requirements.txt",
         "--dev",
         "--without-hashes",
+        *[f"--extras={extra}" for extra in extras],
         external=True,
         silent=True,
         stderr=None,
@@ -187,6 +189,7 @@ def precommit(session: nox.Session) -> None:
 @nox.session(python="3.10")
 def safety(session: nox.Session) -> None:
     """Scan dependencies for insecure packages."""
+    # NOTE: Pass `extras` to `export_requirements` if the project supports any.
     requirements = export_requirements(session)
     install(session, groups=["safety"], root=False)
     session.run("safety", "check", "--full-report", f"--file={requirements}")

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,15 +89,6 @@ def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -
     session.install(wheel.resolve().as_uri())
 
 
-def extras(self: nox_poetry.poetry.Config) -> List[str]:
-    """Return the package extras."""
-    extras = self._config.get("extras", {})
-    assert isinstance(extras, dict) and all(  # noqa: S101
-        isinstance(extra, str) for extra in extras
-    )
-    return list(extras)
-
-
 def export(self: nox_poetry.poetry.Poetry) -> str:
     """Export the lock file to requirements format.
 
@@ -108,12 +99,17 @@ def export(self: nox_poetry.poetry.Poetry) -> str:
         CommandSkippedError: The command `poetry export` was not executed.
     """
     config = nox_poetry.poetry.Config(Path.cwd())
+    _extras = self._config.get("extras", {})
+    assert isinstance(_extras, dict) and all(  # noqa: S101
+        isinstance(extra, str) for extra in _extras
+    )
+    extras = list(_extras)
     output = self.session.run_always(
         "poetry",
         "export",
         "--format=requirements.txt",
         "--dev",
-        *[f"--extras={extra}" for extra in extras(config)],
+        *[f"--extras={extra}" for extra in extras],
         "--without-hashes",
         external=True,
         silent=True,

--- a/noxfile.py
+++ b/noxfile.py
@@ -91,18 +91,16 @@ def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -
 def export_requirements(session: nox.Session) -> Path:
     """Export a requirements file from Poetry.
 
-    This function uses `poetry export`_ to generate a :ref:`requirements
-    file <Requirements Files>` containing the project dependencies at the
-    versions specified in ``poetry.lock``. The requirements file includes
-    both core and development dependencies.
+    This function uses ``poetry export`` to generate a requirements file
+    containing the project dependencies at the versions specified in
+    ``poetry.lock``. The requirements file includes both core and development
+    dependencies.
 
-    .. _poetry export: https://python-poetry.org/docs/cli/#export
+    Args:
+        session: The Session object.
 
     Returns:
         The path to the requirements file.
-
-    Raises:
-        CommandSkippedError: The command `poetry export` was not executed.
     """
     output = session.run_always(
         "poetry",

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,18 +79,18 @@ def build_package(session: nox.Session) -> str:
     return url
 
 
-def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
+def installroot(session: nox.Session) -> None:
     """Install the root package into a Nox session using Poetry.
 
     This function installs the package located in the current directory into the
     session's virtual environment.
     """
     try:
-        package = build_package(self.session)  # type: ignore[attr-defined]
+        package = build_package(session)
     except nox_poetry.poetry.CommandSkippedError:
         pass
     else:
-        self.session.install(package)  # type: ignore[attr-defined]
+        session.install(package)
 
 
 def install(session: nox.Session, *, groups: Iterable[str], only: bool = False) -> None:
@@ -110,7 +110,7 @@ def install(session: nox.Session, *, groups: Iterable[str], only: bool = False) 
         external=True,
     )
     if not only:
-        installroot(nox_poetry.Session(session).poetry)
+        installroot(session)
 
 
 def activate_virtualenv_in_precommit_hooks(session: nox.Session) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -184,12 +184,18 @@ def xdoctest(session: nox.Session) -> None:
     session.run("python", "-m", "xdoctest", package, *args)
 
 
-@session(name="docs-build", python="3.10")
-def docs_build(session: Session) -> None:
+@nox.session(name="docs-build", python="3.10")
+def docs_build(session: nox.Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]
-    session.install(".")
-    session.install("sphinx", "sphinx-click", "furo")
+    session.run(
+        "poetry",
+        "install",
+        "--with",
+        "docs",
+        "--sync",
+        external=True,
+    )
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():
@@ -198,12 +204,18 @@ def docs_build(session: Session) -> None:
     session.run("sphinx-build", *args)
 
 
-@session(python="3.10")
-def docs(session: Session) -> None:
+@nox.session(python="3.10")
+def docs(session: nox.Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""
     args = session.posargs or ["--open-browser", "docs", "docs/_build"]
-    session.install(".")
-    session.install("sphinx", "sphinx-autobuild", "sphinx-click", "furo")
+    session.run(
+        "poetry",
+        "install",
+        "--with",
+        "docs",
+        "--sync",
+        external=True,
+    )
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,27 +57,21 @@ def installroot(session: nox.Session) -> None:
     .. _poetry build: https://python-poetry.org/docs/cli/#export
 
     """
-    try:
-        output = session.run_always(
-            "poetry", "build", "--format=wheel", external=True, silent=True, stderr=None
-        )
+    output = session.run_always(
+        "poetry", "build", "--format=wheel", external=True, silent=True, stderr=None
+    )
 
-        if output is None:
-            raise nox_poetry.poetry.CommandSkippedError(
-                "The command `poetry build` was not executed"
-                " (a possible cause is specifying `--no-install`)"
-            )
+    if output is None:
+        return
 
-        assert isinstance(output, str)  # noqa: S101
+    assert isinstance(output, str)  # noqa: S101
 
-        wheel = Path("dist") / output.split()[-1]
-        url: str = wheel.resolve().as_uri()
+    wheel = Path("dist") / output.split()[-1]
+    url: str = wheel.resolve().as_uri()
 
-        package = url
-    except nox_poetry.poetry.CommandSkippedError:
-        pass
-    else:
-        session.install(package)
+    package = url
+
+    session.install(package)
 
 
 def install(session: nox.Session, *, groups: Iterable[str], only: bool = False) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -87,7 +87,9 @@ def activate_virtualenv_in_precommit_hooks(session: nox.Session) -> None:
 def precommit(session: nox.Session) -> None:
     """Lint using pre-commit."""
     args = session.posargs or ["run", "--all-files", "--show-diff-on-failure"]
-    session.run("poetry", "install", "--only", "pre-commit", "--sync", external=True)
+    session.run_always(
+        "poetry", "install", "--only", "pre-commit", "--sync", external=True
+    )
     session.run("pre-commit", *args)
     if args and args[0] == "install":
         activate_virtualenv_in_precommit_hooks(session)
@@ -97,7 +99,7 @@ def precommit(session: nox.Session) -> None:
 def safety(session: nox.Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = Session(session).poetry.export_requirements()
-    session.run("poetry", "install", "--only", "safety", "--sync", external=True)
+    session.run_always("poetry", "install", "--only", "safety", "--sync", external=True)
     session.run("safety", "check", "--full-report", f"--file={requirements}")
 
 
@@ -145,7 +147,9 @@ def coverage(session: nox.Session) -> None:
     """Produce the coverage report."""
     args = session.posargs or ["report"]
 
-    session.run("poetry", "install", "--only", "coverage", "--sync", external=True)
+    session.run_always(
+        "poetry", "install", "--only", "coverage", "--sync", external=True
+    )
 
     if not session.posargs and any(Path().glob(".coverage.*")):
         session.run("coverage", "combine")

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,11 +40,9 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     This function installs the package located in the current directory into the
     session's virtual environment.
     """
-    from nox_poetry.poetry import CommandSkippedError
-
     try:
         package = self.build_package()
-    except CommandSkippedError:
+    except nox_poetry.poetry.CommandSkippedError:
         pass
     else:
         self.session.install(package)  # type: ignore[attr-defined]

--- a/noxfile.py
+++ b/noxfile.py
@@ -99,11 +99,10 @@ def export(self: nox_poetry.poetry.Poetry) -> str:
         CommandSkippedError: The command `poetry export` was not executed.
     """
     config = nox_poetry.poetry.Config(Path.cwd())
-    _extras = self._config.get("extras", {})
-    assert isinstance(_extras, dict) and all(  # noqa: S101
-        isinstance(extra, str) for extra in _extras
+    extras = self._config.get("extras", {})
+    assert isinstance(extras, dict) and all(  # noqa: S101
+        isinstance(extra, str) for extra in extras
     )
-    extras = list(_extras)
     output = self.session.run_always(
         "poetry",
         "export",

--- a/noxfile.py
+++ b/noxfile.py
@@ -135,6 +135,11 @@ def mypy(session: nox.Session) -> None:
 def tests(session: nox.Session) -> None:
     """Run the test suite."""
     install(session, groups=["coverage", "tests"])
+
+    if session.python == "3.10":
+        # Workaround an unidentified issue in Poetry 1.2.0a2.
+        session.install("coverage[toml]==6.1.2")
+
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Iterable
 from typing import Iterator
-from typing import List
 
 import nox
 
@@ -98,17 +97,11 @@ def export(self: nox_poetry.poetry.Poetry) -> str:
     Raises:
         CommandSkippedError: The command `poetry export` was not executed.
     """
-    config = nox_poetry.poetry.Config(Path.cwd())
-    extras = self._config.get("extras", {})
-    assert isinstance(extras, dict) and all(  # noqa: S101
-        isinstance(extra, str) for extra in extras
-    )
     output = self.session.run_always(
         "poetry",
         "export",
         "--format=requirements.txt",
         "--dev",
-        *[f"--extras={extra}" for extra in extras],
         "--without-hashes",
         external=True,
         silent=True,

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,6 @@ import nox
 
 try:
     from nox_poetry import Session
-    from nox_poetry import session
 except ImportError:
     message = f"""\
     Nox failed to import the 'nox-poetry' package.

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,10 +36,13 @@ nox.options.sessions = (
 def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -> None:
     """Install the dependency groups using Poetry.
 
-    With ``root=True``, the function installs the package located in the current
-    directory into the session's virtual environment. The function uses `poetry
-    build`_ to build a wheel for the local package. It returns a file URL with
-    the absolute path to the built archive.
+    This function installs the given dependency groups into the session's
+    virtual environment. When ``root`` is true (the default), the function
+    also installs the root package and its default dependencies.
+
+    To avoid an editable install, the root package is not installed using
+    ``poetry install``. Instead, the function uses ``poetry build`` to build a
+    wheel for the root package, and installs the wheel using ``pip install``.
 
     The filename of the archive is extracted from the output Poetry writes
     to standard output, which currently looks like this::
@@ -52,8 +55,6 @@ def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -
     assumptions such as having a clean ``dist`` directory, or
     reconstructing the filename from the package metadata. (Poetry does not
     use PEP 440 for version numbers, so this is non-trivial.)
-
-    .. _poetry build: https://python-poetry.org/docs/cli/#export
 
     Args:
         session: The Session object.

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,11 +112,19 @@ def mypy(session: Session) -> None:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
 
 
-@session(python=python_versions)
-def tests(session: Session) -> None:
+@nox.session(python=python_versions)
+def tests(session: nox.Session) -> None:
     """Run the test suite."""
-    session.install(".")
-    session.install("coverage[toml]", "pytest", "pygments")
+    session.run(
+        "poetry",
+        "install",
+        "--with",
+        "coverage",
+        "--with",
+        "tests",
+        "--sync",
+        external=True,
+    )
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,7 @@ except ImportError:
 
 package = "cookiecutter_hypermodern_python_instance"
 python_versions = ["3.10", "3.9", "3.8", "3.7"]
-nox.needs_version = ">= 2021.6.6"
+nox.needs_version = ">= 2021.10.1"
 nox.options.sessions = (
     "pre-commit",
     "safety",
@@ -104,13 +104,7 @@ def export_requirements(session: nox.Session) -> Path:
     Raises:
         CommandSkippedError: The command `poetry export` was not executed.
     """
-    # Avoid ``session.virtualenv.location`` because PassthroughEnv does not
-    # have it. We'll just create a fake virtualenv directory in this case.
-
-    tmpdir = Path(session._runner.envdir) / "tmp"
-    tmpdir.mkdir(exist_ok=True, parents=True)
-
-    path = tmpdir / "requirements.txt"
+    path = session.cache_dir / "requirements.txt"
     output = session.run_always(
         "poetry",
         "export",

--- a/noxfile.py
+++ b/noxfile.py
@@ -169,12 +169,18 @@ def typeguard(session: nox.Session) -> None:
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 
-@session(python=python_versions)
-def xdoctest(session: Session) -> None:
+@nox.session(python=python_versions)
+def xdoctest(session: nox.Session) -> None:
     """Run examples with xdoctest."""
     args = session.posargs or ["all"]
-    session.install(".")
-    session.install("xdoctest[colors]")
+    session.run(
+        "poetry",
+        "install",
+        "--with",
+        "xdoctest",
+        "--sync",
+        external=True,
+    )
     session.run("python", "-m", "xdoctest", package, *args)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -88,8 +88,10 @@ def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -
         "--{}={}".format("only" if not root else "with", ",".join(groups)),
         external=True,
     )
-    if root:
-        installroot(session)
+    if not root:
+        return
+
+    installroot(session)
 
 
 def activate_virtualenv_in_precommit_hooks(session: nox.Session) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -88,7 +88,7 @@ def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -
     session.install(wheel.resolve().as_uri())
 
 
-def export(self: nox_poetry.poetry.Poetry) -> str:
+def export(session: nox.Session) -> str:
     """Export the lock file to requirements format.
 
     Returns:
@@ -97,7 +97,7 @@ def export(self: nox_poetry.poetry.Poetry) -> str:
     Raises:
         CommandSkippedError: The command `poetry export` was not executed.
     """
-    output = self.session.run_always(
+    output = session.run_always(
         "poetry",
         "export",
         "--format=requirements.txt",
@@ -126,7 +126,7 @@ def export(self: nox_poetry.poetry.Poetry) -> str:
     return "".join(_stripwarnings(output.splitlines(keepends=True)))
 
 
-def export_requirements(self: nox_poetry.sessions._PoetrySession) -> Path:
+def export_requirements(session: nox.Session) -> Path:
     """Export a requirements file from Poetry.
 
     This function uses `poetry export`_ to generate a :ref:`requirements
@@ -142,11 +142,11 @@ def export_requirements(self: nox_poetry.sessions._PoetrySession) -> Path:
     # Avoid ``session.virtualenv.location`` because PassthroughEnv does not
     # have it. We'll just create a fake virtualenv directory in this case.
 
-    tmpdir = Path(self.session._runner.envdir) / "tmp"  # type: ignore[attr-defined]
+    tmpdir = Path(session._runner.envdir) / "tmp"  # type: ignore[attr-defined]
     tmpdir.mkdir(exist_ok=True, parents=True)
 
     path = tmpdir / "requirements.txt"
-    path.write_text(self.poetry.export())  # type: ignore[attr-defined]
+    path.write_text(export(session))  # type: ignore[attr-defined]
 
     return path
 
@@ -214,7 +214,7 @@ def precommit(session: nox.Session) -> None:
 @nox.session(python="3.10")
 def safety(session: nox.Session) -> None:
     """Scan dependencies for insecure packages."""
-    requirements = export_requirements(nox_poetry.Session(session).poetry)
+    requirements = export_requirements(session)
     install(session, groups=["safety"], root=False)
     session.run("safety", "check", "--full-report", f"--file={requirements}")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,6 +64,7 @@ def installroot(session: nox.Session) -> None:
     )
 
     if output is None:
+        # The package build was skipped due to `--no-install`.
         return
 
     assert isinstance(output, str)  # noqa: S101

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,12 +97,13 @@ def export(self: nox_poetry.poetry.Poetry) -> str:
     Raises:
         CommandSkippedError: The command `poetry export` was not executed.
     """
+    config = nox_poetry.poetry.Config(Path.cwd())
     output = self.session.run_always(
         "poetry",
         "export",
         "--format=requirements.txt",
         "--dev",
-        *[f"--extras={extra}" for extra in self.config.extras],
+        *[f"--extras={extra}" for extra in config.extras],
         "--without-hashes",
         external=True,
         silent=True,

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,7 @@ nox.options.sessions = (
 )
 
 
-def build(self: nox_poetry.poetry.Poetry, *, format: str) -> str:
+def build(self: nox_poetry.poetry.Poetry) -> str:
     """Build the package.
 
     The filename of the archive is extracted from the output Poetry writes
@@ -49,22 +49,16 @@ def build(self: nox_poetry.poetry.Poetry, *, format: str) -> str:
     reconstructing the filename from the package metadata. (Poetry does not
     use PEP 440 for version numbers, so this is non-trivial.)
 
-    Args:
-        format: The distribution format, either wheel or sdist.
-
     Returns:
         The basename of the wheel built by Poetry.
 
     Raises:
         CommandSkippedError: The command `poetry build` was not executed.
     """
-    if not isinstance(format, nox_poetry.poetry.DistributionFormat):
-        format = nox_poetry.poetry.DistributionFormat(format)
-
     output = self.session.run_always(
         "poetry",
         "build",
-        f"--format={format}",
+        "--format=wheel",
         external=True,
         silent=True,
         stderr=None,
@@ -95,7 +89,7 @@ def build_package(self: nox_poetry.sessions._PoetrySession) -> str:
     Returns:
         The file URL for the distribution package.
     """
-    wheel = Path("dist") / build(self.poetry, format="wheel")  # type: ignore[attr-defined]
+    wheel = Path("dist") / build(self.poetry)  # type: ignore[attr-defined]
     url: str = wheel.resolve().as_uri()
 
     return url

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,7 @@ def installroot(session: nox.Session) -> None:
     session.install(wheel.resolve().as_uri())
 
 
-def install(session: nox.Session, *, groups: Iterable[str], only: bool = False) -> None:
+def install(session: nox.Session, *, groups: Iterable[str], only: bool) -> None:
     """Install the dependency groups using Poetry.
 
     Args:
@@ -164,7 +164,7 @@ def safety(session: nox.Session) -> None:
 def mypy(session: nox.Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests", "docs/conf.py"]
-    install(session, groups=["mypy", "tests"])
+    install(session, groups=["mypy", "tests"], only=False)
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
@@ -173,7 +173,7 @@ def mypy(session: nox.Session) -> None:
 @nox.session(python=python_versions)
 def tests(session: nox.Session) -> None:
     """Run the test suite."""
-    install(session, groups=["coverage", "tests"])
+    install(session, groups=["coverage", "tests"], only=False)
 
     if session.python == "3.10":
         # Workaround an unidentified issue in Poetry 1.2.0a2.
@@ -202,7 +202,7 @@ def coverage(session: nox.Session) -> None:
 @nox.session(python=python_versions)
 def typeguard(session: nox.Session) -> None:
     """Runtime type checking using Typeguard."""
-    install(session, groups=["typeguard", "tests"])
+    install(session, groups=["typeguard", "tests"], only=False)
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 
@@ -210,7 +210,7 @@ def typeguard(session: nox.Session) -> None:
 def xdoctest(session: nox.Session) -> None:
     """Run examples with xdoctest."""
     args = session.posargs or ["all"]
-    install(session, groups=["xdoctest"])
+    install(session, groups=["xdoctest"], only=False)
     session.run("python", "-m", "xdoctest", package, *args)
 
 
@@ -218,7 +218,7 @@ def xdoctest(session: nox.Session) -> None:
 def docs_build(session: nox.Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]
-    install(session, groups=["docs"])
+    install(session, groups=["docs"], only=False)
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():
@@ -231,7 +231,7 @@ def docs_build(session: nox.Session) -> None:
 def docs(session: nox.Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""
     args = session.posargs or ["--open-browser", "docs", "docs/_build"]
-    install(session, groups=["docs"])
+    install(session, groups=["docs"], only=False)
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,7 +40,6 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     This function installs the package located in the current directory into the
     session's virtual environment.
     """
-    from nox_poetry.core import Session_install
     from nox_poetry.poetry import CommandSkippedError
 
     try:
@@ -48,7 +47,7 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     except CommandSkippedError:
         pass
     else:
-        Session_install(self.session, package)  # type: ignore[attr-defined]
+        self.session.install(package)  # type: ignore[attr-defined]
 
 
 def install(session: nox.Session, *, groups: Iterable[str], only: bool = False) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,7 @@ def installroot(session: nox.Session) -> None:
     session.install(wheel.resolve().as_uri())
 
 
-def install(session: nox.Session, *, groups: Iterable[str], root: bool) -> None:
+def install(session: nox.Session, *, groups: Iterable[str], root: bool = True) -> None:
     """Install the dependency groups using Poetry.
 
     Args:
@@ -164,7 +164,7 @@ def safety(session: nox.Session) -> None:
 def mypy(session: nox.Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests", "docs/conf.py"]
-    install(session, groups=["mypy", "tests"], root=True)
+    install(session, groups=["mypy", "tests"])
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
@@ -173,7 +173,7 @@ def mypy(session: nox.Session) -> None:
 @nox.session(python=python_versions)
 def tests(session: nox.Session) -> None:
     """Run the test suite."""
-    install(session, groups=["coverage", "tests"], root=True)
+    install(session, groups=["coverage", "tests"])
 
     if session.python == "3.10":
         # Workaround an unidentified issue in Poetry 1.2.0a2.
@@ -202,7 +202,7 @@ def coverage(session: nox.Session) -> None:
 @nox.session(python=python_versions)
 def typeguard(session: nox.Session) -> None:
     """Runtime type checking using Typeguard."""
-    install(session, groups=["typeguard", "tests"], root=True)
+    install(session, groups=["typeguard", "tests"])
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 
@@ -210,7 +210,7 @@ def typeguard(session: nox.Session) -> None:
 def xdoctest(session: nox.Session) -> None:
     """Run examples with xdoctest."""
     args = session.posargs or ["all"]
-    install(session, groups=["xdoctest"], root=True)
+    install(session, groups=["xdoctest"])
     session.run("python", "-m", "xdoctest", package, *args)
 
 
@@ -218,7 +218,7 @@ def xdoctest(session: nox.Session) -> None:
 def docs_build(session: nox.Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]
-    install(session, groups=["docs"], root=True)
+    install(session, groups=["docs"])
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():
@@ -231,7 +231,7 @@ def docs_build(session: nox.Session) -> None:
 def docs(session: nox.Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""
     args = session.posargs or ["--open-browser", "docs", "docs/_build"]
-    install(session, groups=["docs"], root=True)
+    install(session, groups=["docs"])
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():

--- a/noxfile.py
+++ b/noxfile.py
@@ -101,12 +101,20 @@ def safety(session: nox.Session) -> None:
     session.run("safety", "check", "--full-report", f"--file={requirements}")
 
 
-@session(python=python_versions)
-def mypy(session: Session) -> None:
+@nox.session(python=python_versions)
+def mypy(session: nox.Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests", "docs/conf.py"]
-    session.install(".")
-    session.install("mypy", "pytest")
+    session.run(
+        "poetry",
+        "install",
+        "--with",
+        "mypy",
+        "--with",
+        "tests",
+        "--sync",
+        external=True,
+    )
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")

--- a/noxfile.py
+++ b/noxfile.py
@@ -86,7 +86,7 @@ def installroot(self: nox_poetry.sessions._PoetrySession) -> None:
     session's virtual environment.
     """
     try:
-        package = build_package(self.poetry.session)  # type: ignore[attr-defined]
+        package = build_package(self.session)  # type: ignore[attr-defined]
     except nox_poetry.poetry.CommandSkippedError:
         pass
     else:

--- a/noxfile.py
+++ b/noxfile.py
@@ -123,7 +123,7 @@ def export_requirements(session: nox.Session) -> Path:
     )
 
     if output is None:
-        raise nox_poetry.poetry.CommandSkippedError(
+        session.skip(
             "The command `poetry export` was not executed"
             " (a possible cause is specifying `--no-install`)"
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,12 +34,13 @@ nox.options.sessions = (
 )
 
 
-def build_package(session: nox.Session) -> str:
-    """Build a distribution archive for the package.
+def installroot(session: nox.Session) -> None:
+    """Install the root package into a Nox session using Poetry.
 
-    This function uses `poetry build`_ to build a wheel for the local package,
-    as specified via the ``distribution_format`` parameter. It returns a file
-    URL with the absolute path to the built archive.
+    This function installs the package located in the current directory into the
+    session's virtual environment. The function uses `poetry build`_ to build a
+    wheel for the local package. It returns a file URL with the absolute path to
+    the built archive.
 
     The filename of the archive is extracted from the output Poetry writes
     to standard output, which currently looks like this::
@@ -55,38 +56,24 @@ def build_package(session: nox.Session) -> str:
 
     .. _poetry build: https://python-poetry.org/docs/cli/#export
 
-    Returns:
-        The file URL for the distribution package.
-
-    Raises:
-        CommandSkippedError: The command `poetry build` was not executed.
-    """
-    output = session.run_always(
-        "poetry", "build", "--format=wheel", external=True, silent=True, stderr=None
-    )
-
-    if output is None:
-        raise nox_poetry.poetry.CommandSkippedError(
-            "The command `poetry build` was not executed"
-            " (a possible cause is specifying `--no-install`)"
-        )
-
-    assert isinstance(output, str)  # noqa: S101
-
-    wheel = Path("dist") / output.split()[-1]
-    url: str = wheel.resolve().as_uri()
-
-    return url
-
-
-def installroot(session: nox.Session) -> None:
-    """Install the root package into a Nox session using Poetry.
-
-    This function installs the package located in the current directory into the
-    session's virtual environment.
     """
     try:
-        package = build_package(session)
+        output = session.run_always(
+            "poetry", "build", "--format=wheel", external=True, silent=True, stderr=None
+        )
+
+        if output is None:
+            raise nox_poetry.poetry.CommandSkippedError(
+                "The command `poetry build` was not executed"
+                " (a possible cause is specifying `--no-install`)"
+            )
+
+        assert isinstance(output, str)  # noqa: S101
+
+        wheel = Path("dist") / output.split()[-1]
+        url: str = wheel.resolve().as_uri()
+
+        package = url
     except nox_poetry.poetry.CommandSkippedError:
         pass
     else:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1091,7 +1091,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "098e7fb960304bbac90c8cf3750da5e003c852e478fea417b30700472fca259a"
+content-hash = "49bf0b817b405291df17f661accaf2667201361a49fc7f3dd8b1d126bfa859fc"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1091,7 +1091,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "37ce9bedd59b3838bdf43e033a1fda19c11e841ced0b8448bd30b1c40080a50a"
+content-hash = "445530568871a6a625b6f5df61081ebde8e4bad0e7547458f2063d63f8f8fe64"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1091,7 +1091,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "445530568871a6a625b6f5df61081ebde8e4bad0e7547458f2063d63f8f8fe64"
+content-hash = "9f1cc330eec7b62509579b05c6c0f7edf2614f11681fa2a13c09392d7a9a27af"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1091,7 +1091,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "9f1cc330eec7b62509579b05c6c0f7edf2614f11681fa2a13c09392d7a9a27af"
+content-hash = "098e7fb960304bbac90c8cf3750da5e003c852e478fea417b30700472fca259a"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1091,7 +1091,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "15e25a1aedfd92c2c088c608e3f80638ba9827db6bc8da523c6e4055060238e6"
+content-hash = "37ce9bedd59b3838bdf43e033a1fda19c11e841ced0b8448bd30b1c40080a50a"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,13 @@ optional = true
 [tool.poetry.group.typeguard.dependencies]
 typeguard = "^2.13.0"
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.group.xdoctest]
+optional = true
+
+[tool.poetry.group.xdoctest.dependencies]
 xdoctest = {extras = ["colors"], version = "^0.15.10"}
+
+[tool.poetry.group.dev.dependencies]
 sphinx = "^4.3.0"
 sphinx-autobuild = ">=2021.3.14"
 sphinx-click = "^3.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,10 @@ optional = true
 [tool.poetry.group.xdoctest.dependencies]
 xdoctest = {extras = ["colors"], version = "^0.15.10"}
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
 sphinx = "^4.3.0"
 sphinx-autobuild = ">=2021.3.14"
 sphinx-click = "^3.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,13 @@ optional = true
 [tool.poetry.group.mypy.dependencies]
 mypy = "^0.910"
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.group.typeguard]
+optional = true
+
+[tool.poetry.group.typeguard.dependencies]
 typeguard = "^2.13.0"
+
+[tool.poetry.group.dev.dependencies]
 xdoctest = {extras = ["colors"], version = "^0.15.10"}
 sphinx = "^4.3.0"
 sphinx-autobuild = ">=2021.3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,13 @@ optional = true
 pytest = "^6.2.5"
 Pygments = "^2.10.0"
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.group.mypy]
+optional = true
+
+[tool.poetry.group.mypy.dependencies]
 mypy = "^0.910"
+
+[tool.poetry.group.dev.dependencies]
 typeguard = "^2.13.0"
 xdoctest = {extras = ["colors"], version = "^0.15.10"}
 sphinx = "^4.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,15 +49,20 @@ optional = true
 [tool.poetry.group.coverage.dependencies]
 coverage = {extras = ["toml"], version = "^6.1"}
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.group.tests]
+optional = true
+
+[tool.poetry.group.tests.dependencies]
 pytest = "^6.2.5"
+Pygments = "^2.10.0"
+
+[tool.poetry.group.dev.dependencies]
 mypy = "^0.910"
 typeguard = "^2.13.0"
 xdoctest = {extras = ["colors"], version = "^0.15.10"}
 sphinx = "^4.3.0"
 sphinx-autobuild = ">=2021.3.14"
 sphinx-click = "^3.0.2"
-Pygments = "^2.10.0"
 furo = ">=2021.11.12"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
- update poetry.lock
- pyproject.toml: rename dev-dependencies to group.dev.dependencies
- pyproject.toml: add dependency group for pre-commit
- noxfile: use pre-commit dependency group
- pyproject.toml: add setuptools to pre-commit group (for bandit)
- pyproject.toml: add dependency group for safety
- noxfile: use safety dependency group
- pyproject.toml: add coverage dependency group
- noxfile: use coverage dependency group in coverage session
- pyproject.toml: add tests dependency group
- noxfile: install coverage and tests dependencies in tests session
- pyproject.toml: add mypy dependency group
- noxfile: install mypy and test dependency groups in mypy session
- pyproject.toml: add typeguard dependency group
- noxfile: install typeguard and tests dependency groups in typeguard session
- pyproject.toml: add xdoctest dependency group
- noxfile: install xdoctest dependency group in xdoctest session
- pyproject.toml: add docs dependency group
- noxfile: install docs dependency group in docs and docs-build sessions
- noxfile: use session.run_always for `poetry install`
- noxfile: remove unused import for `nox_poetry.session`
- noxfile: extract function `install`
- noxfile: use qualified name for nox_poetry.Session
- noxfile: work around skipped install for coverage on Python 3.10
- noxfile: copy nox_poetry.sessions._PoetrySession.installroot
- noxfile: remove unused parameters from `installroot`
- noxfile: remove dead code for `extras`
- noxfile: inline variable `distribution_format`
- noxfile: do not pass constraints when installing the root package
- noxfile: do not uninstall root package before installation
- noxfile: use try...else
- noxfile: inline Session_install
- noxfile: use qualified name for `CommandSkippedError`
- noxfile: copy nox_poetry.sessions._PoetrySession.build_package
- noxfile: remove parameter `distribution_format` from `build_package`
- noxfile: inline distributionformat.wheel
- noxfile: copy nox_poetry.poetry.Poetry.build
- noxfile: remove parameter `format` from `build`
- noxfile: inline function `build`
- noxfile: pass nox.Session to `build_package`
- noxfile: remove middle man
- noxfile: remove middle man `_PoetrySession`
- noxfile: inline function `build_package`
- noxfile: replace try...except with early return
- noxfile: inline variables `url` and `package`
- noxfile: document signature of `installroot`
- noxfile: add comment to early return
- noxfile: do not import internal modules from nox_poetry
- noxfile: require `only`
- noxfile: replace `only` with `root`
- noxfile: install root by default in `install`
- noxfile: use early return
- noxfile: inline function `installroot`
- noxfile: update docstring
- noxfile: copy function nox_poetry.sessions._PoetrySession.export_requirements
- noxfile: do not convert requirements to constraints
- noxfile: ignore attr-defined due to type stub
- noxfile: copy function `nox_poetry.poetry.Poetry.export`
- noxfile: do not cache requirements files
- noxfile: inline nox_poetry.poetry.Poetry.config
- noxfile: copy nox_poetry.poetry.Config.extras
- noxfile: inline function `extras`
- noxfile: remove redundant copy of extras
- noxfile: export requirements without extras because we don't have tomlkit
- noxfile: remove middle man
- noxfile: inline function `export`
- noxfile: use session.skip instead of raising an exception
- noxfile: use session.cache_dir for requirements
- noxfile: slide `path` assignment
- noxfile: update docstring for `export_requirements`
- noxfile: remove nox_poetry imports
- CONTRIBUTING: remove nox-poetry
- noxfile: add extras parameter to export_requirements
- CI: bump poetry from 1.1.11 to 1.2.0a2
