### PR TITLE
👷 [github] Enable colors from pre-commit, pytest, Sphinx, and xdoctest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       NOXSESSION: ${{ matrix.session }}
       FORCE_COLOR: "1"
+      PRE_COMMIT_COLOR: "always"
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
 
     env:
       NOXSESSION: ${{ matrix.session }}
+      FORCE_COLOR: "1"
 
     steps:
       - name: Check out the repository

--- a/noxfile.py
+++ b/noxfile.py
@@ -162,10 +162,16 @@ def typeguard(session: Session) -> None:
 @session(python=python_versions)
 def xdoctest(session: Session) -> None:
     """Run examples with xdoctest."""
-    args = session.posargs or ["all"]
+    if session.posargs:
+        args = [package, *session.posargs]
+    else:
+        args = [f"--modname={package}", "--command=all"]
+        if "FORCE_COLOR" in os.environ:
+            args.append("--colored=1")
+
     session.install(".")
     session.install("xdoctest[colors]")
-    session.run("python", "-m", "xdoctest", package, *args)
+    session.run("python", "-m", "xdoctest", *args)
 
 
 @session(name="docs-build", python="3.10")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 """Nox sessions."""
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -171,6 +172,9 @@ def xdoctest(session: Session) -> None:
 def docs_build(session: Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]
+    if not session.posargs and "FORCE_COLOR" in os.environ:
+        args.insert(0, "--color")
+
     session.install(".")
     session.install("sphinx", "sphinx-click", "furo")
 


### PR DESCRIPTION
Enable color output on GitHub Actions for the following tools:

| Tool         | Method                    |
|--------------|---------------------------|
| pre-commit   | `PRE_COMMIT_COLOR=always` |
| pytest       | `FORCE_COLOR=1`           |
| sphinx-build | `--color`                 |
| xdoctest     | `--colored=1`             |
    
- The command-line options for `sphinx-build` and `xdoctest` are passed by their respective Nox sessions when `FORCE_COLOR` is present in the environment.
- Do not enable colors for mypy (`MYPY_FORCE_COLOR`) because this environment variable does not actually have an effect on GitHub Actions, see https://github.com/python/mypy/issues/7771#issuecomment-876508529.
- Do not enable colors for flake8 (`--color=always`) because we cannot pass this option via pre-commit in CI only.
- Do not enable colors for Coverage.py, Typeguard, and safety because they don't currently support colors in the console.
