### PR TITLE
👷 [nox] Combine coverage under the latest Python release

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -138,7 +138,7 @@ def tests(session: Session) -> None:
             session.notify("coverage", posargs=[])
 
 
-@session
+@session(python=python_versions[0])
 def coverage(session: Session) -> None:
     """Produce the coverage report."""
     args = session.posargs or ["report"]


### PR DESCRIPTION
Combine coverage data under the latest Python version supported by the measured
code. Combining data from Python 3.10 under Python 3.9 produces false positives
in branch coverage, where arcs leaving loop blocks are reported as missing.

Previously, the coverage session used the same Python interpreter as Nox. This
worked fine in CI, but could trigger the problem in local development, if Nox
was installed under an older interpreter such as Python 3.9.
