### PR TITLE
✨ [nox] Support patching pre-commit hooks written in bash

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -78,7 +78,11 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                     {session.bin!r},
                     os.environ.get("PATH", ""),
                 ))
-                """
+                """,
+            "bash": f"""\
+                VIRTUAL_ENV={shlex.quote(virtualenv)}
+                PATH={shlex.quote(session.bin)}{os.pathsep}"$PATH"
+                """,
         }
         if "python" in lines[0].lower():
             # pre-commit < 2.16.0
@@ -88,13 +92,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
 
         elif "bash" in lines[0].lower():
             # pre-commit >= 2.16.0
-            header = dedent(
-                f"""\
-                VIRTUAL_ENV={shlex.quote(virtualenv)}
-                PATH={shlex.quote(session.bin)}{os.pathsep}"$PATH"
-                """
-            )
-
+            header = dedent(patches["bash"])
             lines.insert(1, header)
             hook.write_text("\n".join(lines))
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,7 +60,11 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             continue
 
         text = hook.read_text()
-        bindirs = [repr(session.bin)[1:-1]]  # strip quotes
+        bindirs = [repr(session.bin), shlex.quote(session.bin)]
+
+        # Strip quotes so we can detect <bindir>/python too.
+        bindirs = [bindir[1:-1] for bindir in bindirs]
+
         if not any(
             Path("A") == Path("a") and bindir.lower() in text.lower() or bindir in text
             for bindir in bindirs

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,7 +70,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
         if not lines[0].startswith("#!"):
             continue
 
-        patches = {
+        headers = {
             # pre-commit < 2.16.0
             "python": f"""\
                 import os
@@ -87,7 +87,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                 """,
         }
 
-        for executable, patch in patches.items():
+        for executable, patch in headers.items():
             if executable in lines[0].lower():
                 lines.insert(1, dedent(patch))
                 hook.write_text("\n".join(lines))

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 """Nox sessions."""
 import os
+import shlex
 import shutil
 import sys
 from pathlib import Path
@@ -78,6 +79,17 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                     {session.bin!r},
                     os.environ.get("PATH", ""),
                 ))
+                """
+            )
+
+            lines.insert(1, header)
+            hook.write_text("\n".join(lines))
+
+        elif "bash" in lines[0].lower():
+            header = dedent(
+                f"""\
+                VIRTUAL_ENV={shlex.quote(virtualenv)}
+                PATH={shlex.quote(session.bin)}{os.pathsep}"$PATH"
                 """
             )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -87,9 +87,9 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                 """,
         }
 
-        for executable in ("python", "bash"):
+        for executable, patch in patches.items():
             if executable in lines[0].lower():
-                header = dedent(patches[executable])
+                header = dedent(patch)
                 lines.insert(1, header)
                 hook.write_text("\n".join(lines))
                 break

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,9 +60,10 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             continue
 
         text = hook.read_text()
-        bindir = repr(session.bin)[1:-1]  # strip quotes
-        if not (
+        bindirs = [repr(session.bin)[1:-1]]  # strip quotes
+        if not any(
             Path("A") == Path("a") and bindir.lower() in text.lower() or bindir in text
+            for bindir in bindirs
         ):
             continue
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,6 +84,9 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
         if hook.name.endswith(".sample") or not hook.is_file():
             continue
 
+        if not hook.read_bytes().startswith(b"#!"):
+            continue
+
         text = hook.read_text()
 
         if not any(
@@ -93,8 +96,6 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             continue
 
         lines = text.splitlines()
-        if not hook.read_bytes().startswith(b"#!"):
-            continue
 
         for executable, header in headers.items():
             if executable in lines[0].lower():

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,6 +71,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             continue
 
         patches = {
+            # pre-commit < 2.16.0
             "python": f"""\
                 import os
                 os.environ["VIRTUAL_ENV"] = {virtualenv!r}
@@ -79,19 +80,18 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                     os.environ.get("PATH", ""),
                 ))
                 """,
+            # pre-commit >= 2.16.0
             "bash": f"""\
                 VIRTUAL_ENV={shlex.quote(virtualenv)}
                 PATH={shlex.quote(session.bin)}{os.pathsep}"$PATH"
                 """,
         }
         if "python" in lines[0].lower():
-            # pre-commit < 2.16.0
             header = dedent(patches["python"])
             lines.insert(1, header)
             hook.write_text("\n".join(lines))
 
         elif "bash" in lines[0].lower():
-            # pre-commit >= 2.16.0
             header = dedent(patches["bash"])
             lines.insert(1, header)
             hook.write_text("\n".join(lines))

--- a/noxfile.py
+++ b/noxfile.py
@@ -48,8 +48,10 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
     assert session.bin is not None  # noqa: S101
 
     # Strip quotes so we can detect <bindir>/python too.
-    bindirs = [repr(session.bin), shlex.quote(session.bin)]
-    bindirs = [bindir[1:-1] if bindir[0] in "'\"" else bindir for bindir in bindirs]
+    bindirs = [
+        bindir[1:-1] if bindir[0] in "'\"" else bindir
+        for bindir in (repr(session.bin), shlex.quote(session.bin))
+    ]
 
     virtualenv = session.env.get("VIRTUAL_ENV")
     if virtualenv is None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -87,9 +87,9 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                 """,
         }
 
-        for executable, patch in headers.items():
+        for executable, header in headers.items():
             if executable in lines[0].lower():
-                lines.insert(1, dedent(patch))
+                lines.insert(1, dedent(header))
                 hook.write_text("\n".join(lines))
                 break
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -69,22 +69,20 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
         if not lines[0].startswith("#!"):
             continue
 
-        if "python" not in lines[0].lower():
-            continue
+        if "python" in lines[0].lower():
+            header = dedent(
+                f"""\
+                import os
+                os.environ["VIRTUAL_ENV"] = {virtualenv!r}
+                os.environ["PATH"] = os.pathsep.join((
+                    {session.bin!r},
+                    os.environ.get("PATH", ""),
+                ))
+                """
+            )
 
-        header = dedent(
-            f"""\
-            import os
-            os.environ["VIRTUAL_ENV"] = {virtualenv!r}
-            os.environ["PATH"] = os.pathsep.join((
-                {session.bin!r},
-                os.environ.get("PATH", ""),
-            ))
-            """
-        )
-
-        lines.insert(1, header)
-        hook.write_text("\n".join(lines))
+            lines.insert(1, header)
+            hook.write_text("\n".join(lines))
 
 
 @session(name="pre-commit", python=python_versions[0])

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,7 +47,9 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
     """
     assert session.bin is not None  # noqa: S101
 
-    # Strip quotes so we can detect <bindir>/python too.
+    # Only patch hooks containing a reference to this session's bindir. Support
+    # quoting rules for Python and bash, but strip the outermost quotes so we
+    # can detect paths within the bindir, like <bindir>/python.
     bindirs = [
         bindir[1:-1] if bindir[0] in "'\"" else bindir
         for bindir in (repr(session.bin), shlex.quote(session.bin))

--- a/noxfile.py
+++ b/noxfile.py
@@ -49,7 +49,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
 
     # Strip quotes so we can detect <bindir>/python too.
     bindirs = [repr(session.bin), shlex.quote(session.bin)]
-    bindirs = [bindir[1:-1] for bindir in bindirs]
+    bindirs = [bindir[1:-1] if bindir[0] in "'\"" else bindir for bindir in bindirs]
 
     virtualenv = session.env.get("VIRTUAL_ENV")
     if virtualenv is None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -93,7 +93,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             continue
 
         lines = text.splitlines()
-        if not lines[0].startswith("#!"):
+        if not hook.read_bytes().startswith(b"#!"):
             continue
 
         for executable, header in headers.items():

--- a/noxfile.py
+++ b/noxfile.py
@@ -86,15 +86,13 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                 PATH={shlex.quote(session.bin)}{os.pathsep}"$PATH"
                 """,
         }
-        if "python" in lines[0].lower():
-            header = dedent(patches["python"])
-            lines.insert(1, header)
-            hook.write_text("\n".join(lines))
 
-        elif "bash" in lines[0].lower():
-            header = dedent(patches["bash"])
-            lines.insert(1, header)
-            hook.write_text("\n".join(lines))
+        for executable in ("python", "bash"):
+            if executable in lines[0].lower():
+                header = dedent(patches[executable])
+                lines.insert(1, header)
+                hook.write_text("\n".join(lines))
+                break
 
 
 @session(name="pre-commit", python=python_versions[0])

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,8 +89,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
 
         for executable, patch in patches.items():
             if executable in lines[0].lower():
-                header = dedent(patch)
-                lines.insert(1, header)
+                lines.insert(1, dedent(patch))
                 hook.write_text("\n".join(lines))
                 break
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,7 +66,10 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             continue
 
         lines = text.splitlines()
-        if not (lines[0].startswith("#!") and "python" in lines[0].lower()):
+        if not lines[0].startswith("#!"):
+            continue
+
+        if "python" not in lines[0].lower():
             continue
 
         header = dedent(

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,6 +71,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             continue
 
         if "python" in lines[0].lower():
+            # pre-commit < 2.16.0
             header = dedent(
                 f"""\
                 import os
@@ -86,6 +87,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             hook.write_text("\n".join(lines))
 
         elif "bash" in lines[0].lower():
+            # pre-commit >= 2.16.0
             header = dedent(
                 f"""\
                 VIRTUAL_ENV={shlex.quote(virtualenv)}

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,10 +70,8 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
         if not lines[0].startswith("#!"):
             continue
 
-        if "python" in lines[0].lower():
-            # pre-commit < 2.16.0
-            header = dedent(
-                f"""\
+        patches = {
+            "python": f"""\
                 import os
                 os.environ["VIRTUAL_ENV"] = {virtualenv!r}
                 os.environ["PATH"] = os.pathsep.join((
@@ -81,8 +79,10 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                     os.environ.get("PATH", ""),
                 ))
                 """
-            )
-
+        }
+        if "python" in lines[0].lower():
+            # pre-commit < 2.16.0
+            header = dedent(patches["python"])
             lines.insert(1, header)
             hook.write_text("\n".join(lines))
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,6 +47,10 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
     """
     assert session.bin is not None  # noqa: S101
 
+    # Strip quotes so we can detect <bindir>/python too.
+    bindirs = [repr(session.bin), shlex.quote(session.bin)]
+    bindirs = [bindir[1:-1] for bindir in bindirs]
+
     virtualenv = session.env.get("VIRTUAL_ENV")
     if virtualenv is None:
         return
@@ -60,10 +64,6 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             continue
 
         text = hook.read_text()
-        bindirs = [repr(session.bin), shlex.quote(session.bin)]
-
-        # Strip quotes so we can detect <bindir>/python too.
-        bindirs = [bindir[1:-1] for bindir in bindirs]
 
         if not any(
             Path("A") == Path("a") and bindir.lower() in text.lower() or bindir in text


### PR DESCRIPTION
pre-commit 2.16.0 switched from Python to bash in the hooks installed to `.git/hooks`. We're patching hook scripts to activate the virtualenv for the `pre-commit` Nox session. This PR teaches the Nox session to detect bash hooks. The inserted fragment for virtualenv activation was ported to bash.

This PR also fixes a potential crash when files in the hook directory cannot be opened using the default text encoding. We're now checking that the binary file contents start with the shebang sequence `#!` before attempting to decode the contents. That should at least deal with binaries. Scripts with random garbage will still cause the hook installation to crash.

- 🔨 Split conditional
- 🔨 Replace `if not continue` with `if`
- ✨ Add bash version
- 🔨 Add comments with pre-commit version ranges
- 🔨 Extract variable `patches`
- :hammer: Move bash fragment into `patches`
- 🔨 Slide comments
- :hammer: Replace `if...elif` with `for...if...break` loop over `patches`
- 🔨 Do not duplicate `patches` keys
- 🔨 Inline variable `header`
- 🔨 Rename variable `patches` to `headers`
- 🔨 Rename variable `patch` to `header`
- :hammer: Support multiple languages when checking for bindir
- ✨ Support bash when checking for bindir
- 🔨 Slide `bindirs` before loop
- 🐛 Fix over-aggressive quote removal for bindir in bash hooks
- 🔨 Inline variable `bindirs` into `bindirs`
- 💡 Expand comment
- 🔨 Slide `headers` before loop
- 🔨 Replace `lines[0].startswith` with `hook.read_bytes().startswith`
- 🐛 Do not attempt to decode hooks unless they have a shebang
