### PR TITLE
🐛 [nox] Fix patching of pre-commit hooks on Git Bash for Windows

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
         # pre-commit >= 2.16.0
         "bash": f"""\
             VIRTUAL_ENV={shlex.quote(virtualenv)}
-            PATH={shlex.quote(session.bin)}{os.pathsep}"$PATH"
+            PATH={shlex.quote(session.bin)}"{os.pathsep}$PATH"
             """,
     }
 


### PR DESCRIPTION
The patched pre-commit hooks installed by the `pre-commit` Nox session modify the `PATH` environment variable, using `os.pathsep` to separate prepended paths. On Git Bash for Windows, the path separator (`;`) is a shell-special character and needs to be quoted. This commit fixes the Nox session to quote the path separator when patching installed hooks.

This fixes the following error on Windows when invoking pre-commit hooks from Git:

```
.git/hooks/pre-commit: line 3: C:\Users\User\hypermodern-python\.nox\pre-commit\Scripts: Is a directory
.git/hooks/pre-commit: line 13: dirname: command not found
An error has occurred: FatalError: git failed. Is it installed, and are you in a Git repository directory?
```

This issue does not affect pre-commit when run via Nox and in CI.