### PR TITLE
Fix broken contributing link on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,5 @@ This project was generated from `@cjolowicz`_'s `Hypermodern Python Cookiecutter
 .. _Hypermodern Python Cookiecutter: https://github.com/cjolowicz/cookiecutter-hypermodern-python
 .. _file an issue: https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/issues
 .. _pip: https://pip.pypa.io/
-.. github-only
-.. _Contributor Guide: CONTRIBUTING.rst
+.. _Contributor Guide: https://cookiecutter-hypermodern-python-instance.readthedocs.io/en/latest/contributing.html
 .. _Usage: https://cookiecutter-hypermodern-python-instance.readthedocs.io/en/latest/usage.html

--- a/README.rst
+++ b/README.rst
@@ -97,5 +97,6 @@ This project was generated from `@cjolowicz`_'s `Hypermodern Python Cookiecutter
 .. _Hypermodern Python Cookiecutter: https://github.com/cjolowicz/cookiecutter-hypermodern-python
 .. _file an issue: https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/issues
 .. _pip: https://pip.pypa.io/
+.. github-only
 .. _Contributor Guide: https://cookiecutter-hypermodern-python-instance.readthedocs.io/en/latest/contributing.html
 .. _Usage: https://cookiecutter-hypermodern-python-instance.readthedocs.io/en/latest/usage.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,4 @@
 .. include:: ../README.rst
-   :end-before: github-only
-
-.. _Contributor Guide: contributing.html
-.. _Usage: usage.html
 
 .. toctree::
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,8 @@
 .. include:: ../README.rst
+   :end-before: github-only
+
+.. _Contributor Guide: contributing.html
+.. _Usage: usage.html
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
- When you remove `github-only` RST session and put full paths to RTD it simply works everywhere.
I tried in my own repo, you can check out: https://pypi.org/project/git-portfolio/

Closes https://github.com/cjolowicz/cookiecutter-hypermodern-python/issues/1091