### PR TITLE
Fix permanently moved links on Readme and Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -95,9 +95,9 @@ Attribution
 -----------
 
 This Code of Conduct is adapted from the `Contributor Covenant <homepage_>`__, version 2.0,
-available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct/.
 
-Community Impact Guidelines were inspired by `Mozilla’s code of conduct enforcement ladder <https://github.com/mozilla/diversity>`__.
+Community Impact Guidelines were inspired by `Mozilla’s code of conduct enforcement ladder <https://github.com/mozilla/inclusion>`__.
 
 .. _homepage: https://www.contributor-covenant.org
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Cookiecutter Hypermodern Python Instance
    :target: https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/actions?workflow=Tests
    :alt: Tests
 .. |Codecov| image:: https://codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance
+   :target: https://app.codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance
    :alt: Codecov
 .. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
    :target: https://github.com/pre-commit/pre-commit


### PR DESCRIPTION
Closes https://github.com/cjolowicz/cookiecutter-hypermodern-python/issues/1095