### PR TITLE
🔧 [dependabot] Reduce merge conflicts using the lockfile-only strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,4 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
Dependabot updates version constraints in pyproject.toml even when the version constraint already covers the new version, leading to frequent merge conflicts because the global content hash in poetry.lock changes. See https://github.com/dependabot/dependabot-core/issues/4435 for details.

As of cjolowicz/cookiecutter-hypermodern-python-instance#744, this project template no longer uses upper version bounds for its dependencies. As a result, we are now able to use the "lockfile-only" versioning strategy to upgrade dependencies, including major version bumps. This strategy prevents Dependabot from modifying pyproject.toml, putting an end to the frequent merge conflicts.
