### PR TITLE
🔧 [dependabot] Enable automated updates for indirect dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,5 @@ updates:
     schedule:
       interval: daily
     versioning-strategy: lockfile-only
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
Configure Dependabot to keep both direct and indirect dependencies updated.

While the default setting of upgrading only direct dependencies means less churn, it also results in checks being run with increasingly outdated dependencies -- unless users are mindful of performing frequent manual updates. But typically they won't be because this project template *appears* to be automating all dependency updates. Often these outdated dependencies are only discovered when they get flagged by safety or Dependabot alerts due to security vulnerabilities.