### PR TITLE
Move darglint to its own manual pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
         entry: check-yaml
         language: system
         types: [yaml]
+      - id: darglint
+        name: darglint
+        entry: darglint
+        language: system
+        types: [python]
+        stages: [manual]
       - id: end-of-file-fixer
         name: Fix End of Files
         entry: end-of-file-fixer
@@ -33,6 +39,7 @@ repos:
         language: system
         types: [python]
         require_serial: true
+        args: [--darglint-ignore-regex, .*]
       - id: isort
         name: isort
         entry: isort

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,12 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
 @session(name="pre-commit", python=python_versions[0])
 def precommit(session: Session) -> None:
     """Lint using pre-commit."""
-    args = session.posargs or ["run", "--all-files", "--show-diff-on-failure"]
+    args = session.posargs or [
+        "run",
+        "--all-files",
+        "--hook-stage=manual",
+        "--show-diff-on-failure",
+    ]
     session.install(
         "black",
         "darglint",


### PR DESCRIPTION
Moves darglint to its own manual-stage pre-commit hook.

With this change, darglint will no longer run by default on every commit. But will run when the nox pre-commit session is called.

```console
% nox --session=pre-commit
```

Allowing us to still lint arguments in docstrings on demand and in the project's CI, while avoiding dealing with long wait times on each commit. 

Fixes https://github.com/cjolowicz/cookiecutter-hypermodern-python/issues/1137
