### PR TITLE
Restore upper bound to Python version constraint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1106,8 +1106,8 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7"
-content-hash = "a7f1c7e6801812a0144c94e6ec99283c72df724ce5b34e688c3360d5490c0c9a"
+python-versions = "^3.7"
+content-hash = "bc0ff66980ea044bb6b4fa30baa5d376b838cb48d19cd8253c17ada632282f5a"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1107,7 +1107,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "bc0ff66980ea044bb6b4fa30baa5d376b838cb48d19cd8253c17ada632282f5a"
+content-hash = "1900b973776618b00b3a495afaf7e3577de250e6c7d5068674585f37f4ab5896"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 Changelog = "https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/releases"
 
 [tool.poetry.dependencies]
-python = ">=3.7"
+python = "^3.7"
 click = ">=8.0.1"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ sphinx-autobuild = ">=2021.3.14"
 sphinx-click = ">=3.0.2"
 typeguard = ">=2.13.3"
 xdoctest = {extras = ["colors"], version = ">=0.15.10"}
-myst-parser = {version = ">=0.16.1", python = "<4"}
+myst-parser = {version = ">=0.16.1"}
 
 [tool.poetry.scripts]
 cookiecutter-hypermodern-python-instance = "cookiecutter_hypermodern_python_instance.__main__:main"


### PR DESCRIPTION
- Restore upper bound on Requires-Python
- Remove python_version environment marker on myst-parser

Fixes https://github.com/cjolowicz/cookiecutter-hypermodern-python/issues/1148
Fixes https://github.com/cjolowicz/cookiecutter-hypermodern-python/issues/1154
Supercedes https://github.com/cjolowicz/cookiecutter-hypermodern-python/pull/1151
Supercedes https://github.com/cjolowicz/cookiecutter-hypermodern-python/pull/1152