### PR TITLE
Remove redundant `show_error_codes` setting for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ strict = true
 warn_unreachable = true
 pretty = true
 show_column_numbers = true
-show_error_codes = true
 show_error_context = true
 
 [build-system]


### PR DESCRIPTION
This setting has become the default behavior in mypy 0.991.